### PR TITLE
store liked status for songs as session storage so leaving and reentering the room does not reset 

### DIFF
--- a/frontend/src/components/Song/index.js
+++ b/frontend/src/components/Song/index.js
@@ -1,35 +1,44 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import styles from "./style.module.css";
 import axios from "axios";
 import { useCookies } from "react-cookie";
+import { useSessionStorage } from '../../useSessionStorage';
 import IconButton from "@material-ui/core/IconButton";
-import FavoriteIcon from '@material-ui/icons/Favorite'
+import FavoriteIcon from '@material-ui/icons/Favorite';
 
 import {
-    Avatar,
-    TableCell,
-    TableRow,
+  Avatar,
+  TableCell,
+  TableRow,
 
 } from "@material-ui/core";
 
 export default function Song(props) {
-    console.log("I was called");
-    console.log(props);
-    const song = props.props;
-    var formattedArtist = "";
-    song.artists.forEach(function(element) { 
-        if (formattedArtist == ""){
-            formattedArtist = element
-        }else{
-        formattedArtist = formattedArtist + ", " + element
-        }
-        });
-        
-    const [likeButtonColor, setLikeButtonColor] = useState('inherit');
-    const [liked, setLikedStatus] = useState(false);
-    const [cookies, setCookie] = useCookies(["name"]);
+  console.log("I was called");
+  console.log(props);
+  const song = props.props;
+  var formattedArtist = "";
+  song.artists.forEach(function (element) {
+    if (formattedArtist == "") {
+      formattedArtist = element
+    } else {
+      formattedArtist = formattedArtist + ", " + element
+    }
+  });
 
+  const [likeButtonColor, setLikeButtonColor] = useState('inherit');
+  const [liked, setLikedStatus] = useSessionStorage(song.id, false);
+  //const [cachedLike, setCachedLike] = useLocalStorage(song.id, liked);
+  const [cookies, setCookie] = useCookies(["name"]);
 
+  useEffect(() => {
+    setLikedStatus(liked);
+    if (liked) {
+      setLikeButtonColor("secondary");
+    } else {
+      setLikeButtonColor("inherit");
+    }
+  });
 
   const handleLikeButton = async () => {
     setLikedStatus(!liked);
@@ -40,9 +49,9 @@ export default function Song(props) {
       setLikeButtonColor("secondary");
     }
     if (liked) {
-        voteType = "unvote";
+      voteType = "unvote";
     } else {
-        voteType = "upvote";
+      voteType = "upvote";
     }
     const toUpdate = {
       room: cookies.room.id,

--- a/frontend/src/useSessionStorage.js
+++ b/frontend/src/useSessionStorage.js
@@ -1,0 +1,20 @@
+import { useState, useEffect } from 'react';
+
+export function useLocalStorage(key, initialValue = null) {
+
+    const [value, setValue] = useState(() => {
+        try {
+            const data = window.sessionStorage.getItem(key);
+            return data ? JSON.parse(data) : initialValue; 
+        } catch {
+            return initialValue;
+        }
+    });
+
+    useEffect(() => {
+        window.sessionStorage.setItem(key, JSON.stringify(value));
+    }, [value, setValue])
+
+    return [value, setValue];
+
+}


### PR DESCRIPTION
**Issue:**
#85 

**Solution:**
Added session storage custom hook to be used in song component

**Test Method:** 
N/A

**Risk:**
N/A

**Reviewed By:**
Josh
